### PR TITLE
fix interface to not additionally massage data

### DIFF
--- a/sbuf.cpp
+++ b/sbuf.cpp
@@ -254,7 +254,7 @@ std::ostream & operator <<(std::ostream &os,const sbuf_t &t){
 /**
  * Read the requested number of UTF-8 format string octets including any \0.
  */
-void sbuf_t::getUTF8WithQuoting(size_t i, size_t num_octets_requested, std::string &utf8_string) const {
+void sbuf_t::getUTF8(size_t i, size_t num_octets_requested, std::string &utf8_string) const {
     // clear any residual value
     utf8_string = "";
 
@@ -267,15 +267,12 @@ void sbuf_t::getUTF8WithQuoting(size_t i, size_t num_octets_requested, std::stri
         num_octets_requested = bufsize - i;
     }
     utf8_string = std::string((const char *)buf+i,num_octets_requested);
-
-    // validate or escape utf8_string
-    utf8_string = validateOrEscapeUTF8(utf8_string, true, true);
 }
 
 /**
  * Read UTF-8 format code octets into string up to but not including \0.
  */
-void sbuf_t::getUTF8WithQuoting(size_t i, std::string &utf8_string) const {
+void sbuf_t::getUTF8(size_t i, std::string &utf8_string) const {
     // clear any residual value
     utf8_string = "";
 
@@ -292,9 +289,6 @@ void sbuf_t::getUTF8WithQuoting(size_t i, std::string &utf8_string) const {
         // accept the octet
         utf8_string.push_back(octet);
     }
-
-    // validate or escape utf8_string
-    utf8_string = validateOrEscapeUTF8(utf8_string, true, true);
 }
 
 /**

--- a/sbuf.h
+++ b/sbuf.h
@@ -510,8 +510,8 @@ public:
      * @{
      * These get functions safely read string
      */
-    void getUTF8WithQuoting(size_t i, size_t num_octets_requested, std::string &utf8_string) const;
-    void getUTF8WithQuoting(size_t i, std::string &utf8_string) const;
+    void getUTF8(size_t i, size_t num_octets_requested, std::string &utf8_string) const;
+    void getUTF8(size_t i, std::string &utf8_string) const;
     /** @} */
 
     /**

--- a/sbuf_stream.cpp
+++ b/sbuf_stream.cpp
@@ -167,13 +167,13 @@ int64_t sbuf_stream::get64i(sbuf_t::byte_order_t bo) {
 /*
  * string readers
  */
-void sbuf_stream::getUTF8WithQuoting(size_t num_octets_requested, string &utf8_string) {
-    sbuf.getUTF8WithQuoting(num_octets_requested, utf8_string);
+void sbuf_stream::getUTF8(size_t num_octets_requested, string &utf8_string) {
+    sbuf.getUTF8(num_octets_requested, utf8_string);
     offset += utf8_string.length();
     return;
 }
-void sbuf_stream::getUTF8WithQuoting(string &utf8_string) {
-    sbuf.getUTF8WithQuoting(offset, utf8_string);
+void sbuf_stream::getUTF8(string &utf8_string) {
+    sbuf.getUTF8(offset, utf8_string);
     size_t num_bytes = utf8_string.length();
     if (num_bytes > 0) {
         // if anything was read then also skip \0

--- a/sbuf_stream.h
+++ b/sbuf_stream.h
@@ -71,8 +71,8 @@ public:
     /**
      * \name string and wstring stream readers
      * @{ */
-    void getUTF8WithQuoting(string &utf8_string);
-    void getUTF8WithQuoting(size_t num_octets_requested, string &utf8_string);
+    void getUTF8(string &utf8_string);
+    void getUTF8(size_t num_octets_requested, string &utf8_string);
     void getUTF16(wstring &utf16_string);
     void getUTF16(size_t num_code_units_requested, wstring &utf16_string);
     /** @} */


### PR DESCRIPTION
The getUTF8WithQuoting() interfaces are renamed to getUTF8() and the validation and escaping actions, which change the data by correcting invalid unicode and by escaping the backslash character, are removed.

Removing the validation action allows data to be obtained as-is, if needed.

Removing the escape action fixes a bug where text is doubly-escaped since the escape action is additionally performed at a higher level.  Removing escaping also fixes a bug in sbuf_stream::getUTF8WithQuoting() which incorrectly advanced the stream pointer because it incorrectly advanced for inserted escape characters.

Impact of change: Only the exif and winlnk scanners use sbuf_t::getUTF8WithQuoting().  No scanners use sbuf_stream::getUTF8WithQuoting().
