### PR TITLE
Fix build on OpenBSD

### DIFF
--- a/scanner_config.h
+++ b/scanner_config.h
@@ -48,7 +48,7 @@ struct  scanner_config {
     virtual void get_config( const std::string &name, uint32_t *val,    const std::string &help);
     virtual void get_config( const std::string &name, uint16_t *val,    const std::string &help);
     virtual void get_config( const std::string &name, uint8_t *val,     const std::string &help);
-#ifdef __APPLE__
+#ifdef __clang__
     virtual void get_config( const std::string &name, size_t *val,      const std::string &help);
 #define HAVE_GET_CONFIG_SIZE_T
 #endif


### PR DESCRIPTION
size_t hack should check for __clang__, not for __APPLE__.

Similar patches sent to other repositories containing similar code.