### PR TITLE
convert get_config() to template function

### DIFF
--- a/scanner_config.cpp
+++ b/scanner_config.cpp
@@ -21,6 +21,7 @@ void scanner_config::set_config(const std::string &name, const std::string &val)
  * the configuration being requested (by each scanner). Thus, after each of the scanners
  * query for their arguments, it's possible to dump the help stream and find eveyrthing that they were looking for.
  */
+template<>
 void scanner_config::get_config(const std::string &name, std::string *val,const std::string &help)
 {
     std::stringstream ss;
@@ -33,35 +34,17 @@ void scanner_config::get_config(const std::string &name, std::string *val,const 
     }
 }
 
-/* Should this be redone with templates? */
-#define GET_CONFIG(T) void scanner_config::get_config(const std::string &n,T *val,const std::string &help) { \
-        std::stringstream ss;\
-        ss << *val;\
-        std::string v(ss.str());\
-        get_config(n,&v,help);\
-        ss.str(v);\
-        ss >> *val;\
-    }
-
-GET_CONFIG(short)
-GET_CONFIG(int)
-GET_CONFIG(long)
-GET_CONFIG(long long)
-GET_CONFIG(unsigned short)
-GET_CONFIG(unsigned int)
-GET_CONFIG(unsigned long)
-GET_CONFIG(unsigned long long)
-
-
 /* signed/unsigned char need cast to larger type for <<
  * Otherwise it is interpreted as a character.
  */
+template<>
 void scanner_config::get_config(const std::string &n,unsigned char *val_,const std::string &help)
 {
     unsigned int val = *val_;
     get_config(n, &val, help);
     *val_ = (unsigned char)val;
 }
+template<>
 void scanner_config::get_config(const std::string &n,signed char *val_,const std::string &help)
 {
     int val = *val_;
@@ -70,6 +53,7 @@ void scanner_config::get_config(const std::string &n,signed char *val_,const std
 }
 
 /* bool needs special processing for YES/NO/TRUE/FALSE */
+template<>
 void scanner_config::get_config(const std::string &n,bool *val,const std::string &help)
 {
     std::stringstream ss;

--- a/scanner_config.h
+++ b/scanner_config.h
@@ -40,21 +40,11 @@ struct  scanner_config {
     // These methods are implemented in the plugin system for the scanner to get config information.
     // which is why they need to be virtual functions.
     // The get_config methods should be called on the si object during PHASE_STARTUP
-    //virtual void get_config(const scanner_info::config_t &c, const std::string &name,std::string *val,const std::string &help);
-    virtual void set_config( const std::string &name, const std::string &val);
-    virtual void get_config( const std::string &name, std::string *val,        const std::string &help);
-    virtual void get_config( const std::string &name, signed char *val,        const std::string &help);
-    virtual void get_config( const std::string &name, short *val,              const std::string &help);
-    virtual void get_config( const std::string &name, int *val,                const std::string &help);
-    virtual void get_config( const std::string &name, long *val,               const std::string &help);
-    virtual void get_config( const std::string &name, long long *val,          const std::string &help);
-    virtual void get_config( const std::string &name, unsigned char *val,      const std::string &help);
-    virtual void get_config( const std::string &name, unsigned short *val,     const std::string &help);
-    virtual void get_config( const std::string &name, unsigned int *val,       const std::string &help);
-    virtual void get_config( const std::string &name, unsigned long *val,      const std::string &help);
-    virtual void get_config( const std::string &name, unsigned long long *val, const std::string &help);
-    virtual void get_config( const std::string &name, bool *val,               const std::string &help);
-    //virtual int max_depth() const;
+    //void get_config(const scanner_info::config_t &c, const std::string &name,std::string *val,const std::string &help);
+    void set_config( const std::string &name, const std::string &val);
+    template<typename T>
+    void get_config( const std::string &name, T *val,                  const std::string &help);
+    //int max_depth() const;
 
     /**
      * Commands whether to enable or disable a scanner.
@@ -76,5 +66,20 @@ struct  scanner_config {
     /* Control which scanners are enabled */
     void    push_scanner_command(const std::string &scannerName, scanner_command::command_t c); // enable/disable a specific scanner
 };
+
+template<> void scanner_config::get_config( const std::string &name, std::string *val,        const std::string &help);
+template<> void scanner_config::get_config( const std::string &name, signed char *val,        const std::string &help);
+template<> void scanner_config::get_config( const std::string &name, unsigned char *val,      const std::string &help);
+template<> void scanner_config::get_config( const std::string &name, bool *val,               const std::string &help);
+
+template<typename T>
+void scanner_config::get_config(const std::string &n,T *val,const std::string &help) {
+    std::stringstream ss;
+    ss << *val;
+    std::string v(ss.str());
+    get_config(n,&v,help);
+    ss.str(v);
+    ss >> *val;
+}
 
 #endif


### PR DESCRIPTION
For the sake of minimizing code duplication...

We loose the 'virtual' here, but get ability for explicit instantination for almost any type, if needed. And, of course, new code is shorter.

Since `master` branch is still broken, this was only compile-tested for `scanner_config.cpp` only, i.e., no linking check happened. In particular, this change is technically a major ABI change.

Feel free to deny this patch, I've created it to "compensate" the increased number of overloads. :-) At least this patch removes more code than adds.